### PR TITLE
Ignite の更新と「Website」ターゲットの追加

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "23d180b68ac27cae72339a1ac6cb24e29dfb9b7f357061657340fa24ecc29128",
   "pins" : [
     {
       "identity" : "ignite",
@@ -6,7 +7,7 @@
       "location" : "https://github.com/twostraws/Ignite.git",
       "state" : {
         "branch" : "main",
-        "revision" : "c2a22687c197a7d4c60df33845c8ad868970eab6"
+        "revision" : "b73d396eae8e0fdbf0944f162cbdf48f80e479b7"
       }
     },
     {
@@ -21,10 +22,19 @@
     {
       "identity" : "swift-cmark",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "location" : "https://github.com/apple/swift-cmark.git",
       "state" : {
-        "branch" : "gfm",
-        "revision" : "b022b08312decdc46585e0b3440d97f6f22ef703"
+        "revision" : "3ccff77b2dc5b96b77db3da0d68d28068593fa53",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
       }
     },
     {
@@ -32,10 +42,19 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-markdown.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "90a8e2ec3d814093435b76c5e87917bd81785fd4"
+        "revision" : "8f79cb175981458a0a27e76cb42fee8e17b1a993",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "swiftsoup",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scinfu/SwiftSoup.git",
+      "state" : {
+        "revision" : "6b4930da67b462d3f200472c902dd016d37a554d",
+        "version" : "2.7.7"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,17 +1,16 @@
-// swift-tools-version: 5.9
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version: 6.0
 
 import PackageDescription
 
 let package = Package(
-    name: "Japan-Region-Swift",
+    name: "JapanRegionSwiftWebsite",
     platforms: [.macOS(.v13)],
     dependencies: [
         .package(url: "https://github.com/twostraws/Ignite.git", branch: "main")
     ],
     targets: [
         .executableTarget(
-            name: "Japan-Region-Swift",
-            dependencies: ["Ignite"]),
+            name: "Website",
+            dependencies: ["Ignite"])
     ]
 )

--- a/Sources/Website/main.swift
+++ b/Sources/Website/main.swift
@@ -1,0 +1,8 @@
+//
+//  main.swift
+//  JapanRegionSwiftWebsite
+//
+//  Created by treastrain on 2025/02/01.
+//
+
+print("Hello, happy world!")


### PR DESCRIPTION
[twostraws/Ignite](https://github.com/twostraws/Ignite) を twostraws/Ignite@c2a22687c197a7d4c60df33845c8ad868970eab6 から twostraws/Ignite@b73d396eae8e0fdbf0944f162cbdf48f80e479b7 へ更新する。

破壊的変更が含まれるため、それに対応した実行ターゲットへ移行するべく「Website」ターゲットを追加する。今後のウェブサイトに関する変更はそのターゲットにて実施する。